### PR TITLE
Added supporting token parameters to message security.

### DIFF
--- a/WCFCustomClientCredentials/Shared/BindingHelper.cs
+++ b/WCFCustomClientCredentials/Shared/BindingHelper.cs
@@ -13,6 +13,7 @@
             };
 
             var messageSecurity = new SymmetricSecurityBindingElement();
+			messageSecurity.EndpointSupportingTokenParameters.SignedEncrypted.Add(new EchoTokenParameters());
 
             var x509ProtectionParameters = new X509SecurityTokenParameters
             {


### PR DESCRIPTION
Without token parameters new token is not used by WCF at all.
